### PR TITLE
Initial version

### DIFF
--- a/draft-rustignoli-panrg-scion-components.md
+++ b/draft-rustignoli-panrg-scion-components.md
@@ -524,7 +524,7 @@ TODO:  (inclding BGP with colors, semantic routing, ...)
 ### SCION and previous attempts (RFC9049)
 RFC9049 {{RFC9049}} describes previous failed attempts in deploying path-aware networking.
 How does SCION differ from previous failed attempts to deploy path-aware networking? Why?
-- *Banana* (Bandwidth Aggregation for interNet Access) was a  mechanism to support  per-packet path selection in networks with multiple Internet links. Standardization efforts were abandoned due to multiple reasons. First, there was Lack of deployment, HW implications on devices, MP-TCP does the same but on a per-flow level rather than per-packet level. 
+
 - ...
 
 TODO: look at p. 582 of the Book

--- a/draft-rustignoli-panrg-scion-components.md
+++ b/draft-rustignoli-panrg-scion-components.md
@@ -493,6 +493,37 @@ For more information, refer to the draft {{I-D.garciapardo-drkey}}.
 The CP-PKI is based on certificates that follow the X.509v3 standard {{RFC5280}}. There are several professional industry-grade implementations, e.g., by SIX, the main financial infrastructure and service provider in Switzerland.
 Trust within an ISD is normally bootstrapped with an initial ceremony. Subsequent updates to the root of trust are handled automatically.
 
+# Additional components
+
+## Transition mechanisms
+As we presented in {{I-D.dekater-scion-overview}}, SCION comprises multiple transition mechanisms that allow an incremental deployment and coexistence with existing protocols.
+Such approaches require different level of changes in existing systems, and have different maturity levels (from research to production).
+Rather than describing how each mechanism works, we provide a short summary of the approach, focusing on what its functions, properties, and protocols it reuses, extend or interact with.
+
+-  *SCION-IP-Gateway (SIG)*.  A SCION-IP-Gateway (SIG) encapsulates regular IP packets into SCION
+   packets with a corresponding SIG at the destination that performs the
+   decapsulation.
+   This mechanism enables legacy IP end hosts to benefit from a SCION deployment by transparently obtaining improved security and availability properties.
+   SCION routing policies can be configured on SIGs, in order to select appropriate SCION paths based on application requirements.
+   SIGs have the ability to dynamically exchange prefix information, currently using their own encapsulation and prefix exchange protocol. This does not exclude reusing existing protocols in the future.
+   SIGs are deployed in production SCION networks, and there are commercial implementations.
+
+- *SIAM*. To make SIGs a viable transition mechanism in an Internet-scale network with tens of thousands of ASes, an automatic configuration system is required. SIAM creates mappings between legacy IPs and SCION addresses, relying on the authorisations in the Resource Public Key Infrastructure (RPKI). SIAM  is currently a research prototype, further described in {{SUPRAJA2021}}.
+
+- *SBAS* is an experimental architecture aiming at extending benefits of SCION (in terms of performance and routing security) to potentially any IP host on the Internet.
+SBAS consists of a federated backbone of entities. SBAS appears on the outside Internet as a regular BGP-speaking AS. Customers of SBAS can leverage the system to route traffic across the SCION network according to their requirements (i.e., latency, geography, ... ). SBAS contains globally distributed PoPs that advertise its customer's announcements. Traffic is therefore routed as close as possible to the source onto the SCION network. The system is further described in chapter 13 of {{CHUAT22}}.
+
+
+TODO: Maybe instead of having bullet points, we can just have a paragraph. This way we don't give too much importance about this section.
+- *End-host stack*. SCION can be deployed though the use of SICON-to-IP conversion or natively on end hosts.
+- Happy eyeballs (and how we extend it)
+- DrKey & dependencies --> {{I-D.garciapardo-drkey}}
+  - LightningFilter --> https://datatracker.ietf.org/meeting/111/materials/slides-111-panrg-lightning-filter-high-speed-traffic-filtering-based-on-drkey
+  - SCMP
+- COLIBRI (Bandwidth Reservations)
+- *RHINE* (formerly RAINS)
+
+
 ## Related work
 A question that is often asked is wether SCION could simply reuse or extend existing protocols.
 We try to clarify this question, giving an overview of the relationships between SCION and other approaches.
@@ -546,35 +577,6 @@ TODO: look at p. 582 of the Book
 
 We briefly discuss implications of {{RFC5218}} (What Makes for a Successful Protocol?) in {{I-D.dekater-scion-overview}}. Overall, because of the reasons discussed above, we believe SCION avoid many of the other protocol's pitfalls, and can therefore be deployed and standardised.
 
-# Transition mechanisms
-As we presented in {{I-D.dekater-scion-overview}}, SCION comprises multiple transition mechanisms that allow an incremental deployment and coexistence with existing protocols.
-Such approaches require different level of changes in existing systems, and have different maturity levels (from research to production).
-Rather than describing how each mechanism works, we provide a short summary of the approach, focusing on what its functions, properties, and protocols it reuses, extend or interact with.
-
--  *SCION-IP-Gateway (SIG)*.  A SCION-IP-Gateway (SIG) encapsulates regular IP packets into SCION
-   packets with a corresponding SIG at the destination that performs the
-   decapsulation.
-   This mechanism enables legacy IP end hosts to benefit from a SCION deployment by transparently obtaining improved security and availability properties.
-   SCION routing policies can be configured on SIGs, in order to select appropriate SCION paths based on application requirements.
-   SIGs have the ability to dynamically exchange prefix information, currently using their own encapsulation and prefix exchange protocol. This does not exclude reusing existing protocols in the future.
-   SIGs are deployed in production SCION networks, and there are commercial implementations.
-
-- *SIAM*. To make SIGs a viable transition mechanism in an Internet-scale network with tens of thousands of ASes, an automatic configuration system is required. SIAM creates mappings between legacy IPs and SCION addresses, relying on the authorisations in the Resource Public Key Infrastructure (RPKI). SIAM  is currently a research prototype, further described in {{SUPRAJA2021}}.
-
-- *SBAS* is an experimental architecture aiming at extending benefits of SCION (in terms of performance and routing security) to potentially any IP host on the Internet.
-SBAS consists of a federated backbone of entities. SBAS appears on the outside Internet as a regular BGP-speaking AS. Customers of SBAS can leverage the system to route traffic across the SCION network according to their requirements (i.e., latency, geography, ... ). SBAS contains globally distributed PoPs that advertise its customer's announcements. Traffic is therefore routed as close as possible to the source onto the SCION network. The system is further described in chapter 13 of {{CHUAT22}}.
-TODO: I find it very difficult to explain SBAS in a few lines... It is quite a big system and I'm not so sure we should talk about it. I'm afraid it might distract the focus.
-
-
-# Additional components
-TODO: Mayne instead of having bullet points, we can just have a paragraph. This way we don't give too much importance about this section.
-- *End-host stack*. SCION can be deployed though the use of SICON-to-IP conversion or natively on end hosts.
-- Happy eyeballs (and how we extend it)
-- DrKey & dependencies --> {{I-D.garciapardo-drkey}}
-  - LightningFilter --> https://datatracker.ietf.org/meeting/111/materials/slides-111-panrg-lightning-filter-high-speed-traffic-filtering-based-on-drkey
-  - SCMP
-- COLIBRI (Bandwidth Reservations)
-- *RHINE* (formerly RAINS)
 
 
 # Dependency analysis

--- a/draft-rustignoli-panrg-scion-components.md
+++ b/draft-rustignoli-panrg-scion-components.md
@@ -270,22 +270,24 @@ informative:
 
 SCION is a future Internet architecture that focuses on security and availability. Its fundamental functions are carried out by a number of components.
 
-This document illustrates the dependencies between its core components, extensions. We also discuss the relationship between SCION and existing protocols, with focus on illustrating which existing protocols are reused/extended. We also describe the motivations behind cases where a greenfield approach is needed. We also briefly touch on the maturity level of components.
+This document illustrates the dependencies between its core components and extensions. We also discuss the relationship between SCION and existing protocols, with focus on illustrating which existing protocols are reused/extended.
+We also describe the motivations behind cases where a greenfield approach is needed, and the properties that can be achieved thanks to it. We then briefly touch on the maturity level of components.
 
 --- middle
 
 # Introduction
 
 While SCION  was initially developed in academia, the architecture  has now "slipped out of the lab" and counts its early productive deployments (including the Swiss inter-banking network SSFN).
-The architecture consists of a system of related components, some of which are  essential to set up end to end SCION connectivity, while others are add-ons aiming at providing additional functionality, security, or backwards compatibility. Discussions at {{PANRG-INTERIM-Min}} showed the need to describe the relationships between SCION's core components.
+The architecture is composed of a system of related components, some of which are  essential to set up end to end SCION connectivity, while others are add-ons aiming at providing additional functionality, security, or backwards compatibility. Discussions at {{PANRG-INTERIM-Min}} showed the need to describe the relationships between SCION's core components.
 In this document we therefore focus on each component, describing its functionality, dependencies and relationships to existing protocols. The goal is not to describe each component specification, rather to provide a basis for discussions about the engineering decisions that made SCION what it is.
-We first start from core components, that form a SCION minimal stack. We then move onto extensions and additional components, some of which provide compatibility mechanisms between SCION and existing protocols.
+We first start from core components, that form a SCION minimal stack. We then move onto extensions and additional components.
+
+TODO: Feedback Corine.. in the introduction, reiterate why the properties that SCION offers are actually needed and relevant.. Adrian wanted to actually achieve them. For each property, we can first stress how the current Internet fulfills these properties, and then stress why SCION achieves them better. We can do this for the 3 core components.
+So overall, for each property, first explain why they are important, why they cannot be achieved, and why SCION's approach achieves them.
 
 Before reading this document, please refer to {{I-D.dekater-scion-overview}} for a generic overview of SCION and its components, the problems it solves, and existing deployments. For an in-depth description of SCION, please refer to {{CHUAT22}}.
 
-## Conventions and Definitions
-
-{::boilerplate bcp14-tagged}
+# Design goal: fundamental properties
 
 # Minimal stack - core components
 In order to establish end to end connectivity, SCION relies on three main components.
@@ -300,7 +302,7 @@ Both the control and data plane rely on the control-plane PKI for authentication
 SCION's authentication mechanisms aim at protecting the whole end to end path at each hop. SCION Autonomous systems are organised in Isolation Domains (ISDs), that independently define their own roots of trust.
 ISD members share an uniform trust environment (i.e., a common jurisdiction).
 They can transparently define trust relationships between parts of the network by deciding wether to trust other ISDs.
-SCION therefore relies on an unique trust model, which is markably different from other PKI. We clarify the motivation behind this in [Authentication](#pki)
+SCION therefore relies on an unique trust model, which is different from other PKI. We clarify the motivation behind this in [Authentication](#pki)
 
 All above mentioned core components are deployed in production (i.e., they are in use within the the SSFN, the Swiss Finance Network).
 There are commercial implementations of all core components (including a high performance data-plane).
@@ -350,6 +352,13 @@ TODO: Maybe we could go into more detail (i.e. verifying a path with CP certific
 
 TODO: add a few sentences on why the CP avoids mistakes in lessons learned from RFC9049
 
+TODO: Corine feedback: maybe it is good to have global properties mentione before digging into specific components?
+- *Security*: TODO: overview of why SCION is secure
+
+- *Transparency*
+
+- *Path awareness*
+
 ## Forwarding - Data plane
 SCION is an inter-domain network architecture and as such does not interfere with intra-domain forwarding. This corresponds to the general practice today where BGP and IP are used for inter-domain routing and forwarding, respectively, but ASes use an intra-domain protocol of their choice, (i.e., OSPF or IS-IS for routing and IP, MPLS, SR and various layer-2 protocols for forwarding).
 SCION therefore re-uses the intra-domain network fabric to provide connectivity among its infrastructure services, border routers, and end hosts, minimising changes to the internal infrastructure.
@@ -392,7 +401,7 @@ It comes, therefore, with an arsenal of tools to prevent attacks (i.e., authenti
 Rather than competing, SCION and SR could potentially complement each other. SCION relies on existing intra-domain routing protocols, therefore SR could represent one of the possible intra-domain routing protocols. Possible integration of their path-aware properties remain for now an open question.
 
 TODO: Maybe cite https://datatracker.ietf.org/doc/draft-li-spring-srv6-security-consideration/
-
+TODO: maybe this paragraph can go at the end, in a paragraph where we discuss SICON vs related work (inclding BGP with colors, semantic routing, ...)
 
 ## Authentication -  SCION PKI {#pki}
 SCION's control plane messages are all authenticated. The verification of those messages relies on a public-key infrastructure (PKI) called the control-plane PKI or CP-PKI.
@@ -442,7 +451,7 @@ Rather than describing how each mechanism works, we provide a short summary of t
    packets with a corresponding SIG at the destination that performs the
    decapsulation.
    This mechanism enables legacy IP end hosts to benefit from a SCION deployment by transparently obtaining improved security and availability properties.
-   SCION routing policies can be configured on SIGs, in order to selsect appropriate SCION paths based on application requirements.
+   SCION routing policies can be configured on SIGs, in order to select appropriate SCION paths based on application requirements.
    SIGs have the ability to dynamically exchange prefix information, currently using their own encapsulation and prefix exchange protocol. This does not exclude reusing existing protocols in the future.
    SIGs are deployed in production SCION networks, and there are commercial implementations.
 
@@ -454,13 +463,13 @@ TODO: I find it very difficult to explain SBAS in a few lines... It is quite a b
 
 
 # Additional components
-TODO: Add some description
+TODO: Mayne instead of having bullet points, we can just have a paragraph. This way we don't give too much importance about this section.
+- *End-host stack*. SCION can be deployed though the use of SICON-to-IP conversion or natively on end hosts.
 - Happy eyeballs (and how we extend it)
 - DrKey & dependencies --> {{I-D.garciapardo-drkey}}
   - LightningFilter --> https://datatracker.ietf.org/meeting/111/materials/slides-111-panrg-lightning-filter-high-speed-traffic-filtering-based-on-drkey
   - SCMP
 - COLIBRI (Bandwidth Reservations)
-- End-host stack
 - *RHINE* (formerly RAINS)
 
 

--- a/draft-rustignoli-panrg-scion-components.md
+++ b/draft-rustignoli-panrg-scion-components.md
@@ -108,6 +108,21 @@ informative:
         ins: A. Perrig
         name: Adrian Perrig
         org: ETH Zuerich
+  I-D.rtgwg-net2cloud-problem-statement:
+    title: SCION Overview
+    date: 2022
+    target: https://datatracker.ietf.org/doc/draft-ietf-rtgwg-net2cloud-problem-statement/
+    author:
+      -
+        ins: L. Dunbar
+      -
+        ins: A. Malis
+      -
+        ins: C. Jacquenet
+      -
+        ins: M. Toy
+      -
+        ins: K. Majumdar
 
   I-D.garciapardo-drkey:
     title: Dynamically Recreatable Keys
@@ -282,12 +297,31 @@ The architecture is composed of a system of related components, some of which ar
 In this document we therefore focus on each component, describing its functionality, dependencies and relationships to existing protocols. The goal is not to describe each component specification, rather to provide a basis for discussions about the engineering decisions that made SCION what it is.
 We first start from core components, that form a SCION minimal stack. We then move onto extensions and additional components.
 
-TODO: Feedback Corine.. in the introduction, reiterate why the properties that SCION offers are actually needed and relevant.. Adrian wanted to actually achieve them. For each property, we can first stress how the current Internet fulfills these properties, and then stress why SCION achieves them better. We can do this for the 3 core components.
+TODO: Feedback Corine.. in the introduction, reiterate why the properties that SCION offers are actually needed and relevant.. Adrian wanted to actually achieve them. For each property, we can first stress how the current Internet fulfils these properties, and then stress why SCION achieves them better. We can do this for the 3 core components.
 So overall, for each property, first explain why they are important, why they cannot be achieved, and why SCION's approach achieves them.
 
 Before reading this document, please refer to {{I-D.dekater-scion-overview}} for a generic overview of SCION and its components, the problems it solves, and existing deployments. For an in-depth description of SCION, please refer to {{CHUAT22}}.
 
-# Design goal: fundamental properties
+## Design goals
+SCION was created from inception with the intention of providing the following properties for inter-domain communication.
+
+- *Availability*. SCION is meant to provide highly available communication. The focus is not only on handling failures (both on the last hop or anywhere along the path), but also on allowing communication in presence of adversaries.
+Availability is fundamental as applications move to cloud datacenters and enterprises increasingly rely on Internet communication for mission-critical communication.  
+
+- *Security*. SCION was designed by security researchers with the goal of making most network-based and routing attacks either impossible or easy to mitigate.
+Security means also offering end-hosts transparency and control over forwarding paths. In addition, SCION's design starts from the assumption that any two entities on the global Internet do not mutually trust each other.
+SCION therefore enables trust agility, allowing users to decide the roots of trust they wish to rely upon.
+
+- *Scalability*.  Security and high availability should not result in compromises on scalability.
+The S in SCION, indeed, stands for scalability.
+The goal is to achieve routing that scales with network growth, both in the control plane and in the data plane (forwarding should be as efficient as possible).
+
+
+
+Many research efforts have gone in the direction of analysing wether such properties could be achieved by extending the existing Internet architecture.
+Tradeoffs between properties would be unavoidable while exclusively relying or extending existing protocols.
+The following paragraphs describe the key properties of SCION's core components.
+Then, they describe the component's mutual dependencies and their relation with existing protocols.
 
 # Minimal stack - core components
 In order to establish end to end connectivity, SCION relies on three main components.
@@ -393,6 +427,8 @@ Such extensions can be hop-by-hop and end-to-end.
 - *Backwards compatibility.* SCION packets support any kind of end-host addressing. IP packets can therefore be transported over SCION by interposing a SCION to IP Gateway (SIG). TODO: reference if we talk more about it later.
 
 
+## Related work
+TODO: Move this seciton somewhere else
 
 ###  SCION and Segment Routing
 Given its path-aware properties, some of SCION's characteristics might seem similar to the ones provided by Segment Routing (SR) {{RFC8402}}. There are, however, fundamental differences that distinguish and motivate SCION.
@@ -402,6 +438,8 @@ Rather than competing, SCION and SR could potentially complement each other. SCI
 
 TODO: Maybe cite https://datatracker.ietf.org/doc/draft-li-spring-srv6-security-consideration/
 TODO: maybe this paragraph can go at the end, in a paragraph where we discuss SICON vs related work (inclding BGP with colors, semantic routing, ...)
+
+As highlighted in {{I-D.rtgwg-net2cloud-problem-statement}}, as applications move to cloud datacenters, achieving reliable inter-domain Internet connectivity remains an open challenge.
 
 ## Authentication -  SCION PKI {#pki}
 SCION's control plane messages are all authenticated. The verification of those messages relies on a public-key infrastructure (PKI) called the control-plane PKI or CP-PKI.

--- a/draft-rustignoli-panrg-scion-components.md
+++ b/draft-rustignoli-panrg-scion-components.md
@@ -474,7 +474,7 @@ TODO: this section contains just notes, to be rephrased
   The SCION control plane relies on the CP-PKI to authenticate entities. It would therefore make sense to define the CP in parallel with PKI. Decoupling it from PKI would severely affect the properties and guarantees that can be provided by the CP
 
 - Only data plane - path construction and packet forwarding
-  DP needs a way to authenticate path information.. If not, it would not make sense to have SCION for inter-domain.. We would just mimick SR and it would be useless on inter-domain, where the trust model is different. As discussed in {{RFC9092}}, lack of authentication has often been the cause of some protocols never taking off because of security concerns (see Section 6.5 (Trigtran),  6.7 (NSIS) of the mentioned draft. )
+  DP needs a way to authenticate path information.. If not, it would not make sense to have SCION for inter-domain.. We would just mimick SR and it would be useless on inter-domain, where the trust model is different. As discussed in {{RFC9049}}, lack of authentication has often been the cause of some protocols never taking off because of security concerns (see Section 6.5 (Trigtran),  6.7 (NSIS) of the mentioned draft. )
 
 
 - Only other components (i.e., SCMP)

--- a/draft-rustignoli-panrg-scion-components.md
+++ b/draft-rustignoli-panrg-scion-components.md
@@ -84,23 +84,23 @@ informative:
         ins: L. Chuat
         name: Laurent Chuat
         org: ETH Zuerich
-  KING2022:
-    title: Challenges for the Internet Routing Systems Introduced by Semantic Routing
+  DEKATER2022:
+    title: SCION Overview
     date: 2022
-    target: https://datatracker.ietf.org/doc/draft-king-irtf-challenges-in-routing/
+    target: https://datatracker.ietf.org/doc/draft-dekater-panrg-scion-overview/
     author:
       -
-        ins: D. King
-        name: Daniel King
-        org: Lancaster University
+        ins: C. de Kater
+        name: Corine de Kater
+        org: ETH Zuerich
       -
         ins: A. Farrel
-        name: Adrian Farrel
-        org: Old Dog consulting
+        name: Nicola Rustignoli
+        org: ETH Zuerich
       -
-        ins: C. Jacquenet
-        name: Christian Jacquenet
-        org: Orange
+        ins: A. Perrig
+        name: Adrian Perrig
+        org: ETH Zuerich
   HITZ2021:
     title: Demonstrating the reliability and resilience of Secure Swiss Finance Network
     date: 2021
@@ -172,19 +172,40 @@ informative:
 
 --- abstract
 
-TODO Abstract
+SCION is a future Internet architecture that focuses on security and availability. Its fundamental functions are carried out by a number of components.
 
+This document illustrates the dependencies between its core components, extensions. We also discuss the relationship between SCION and existing protocols, with focus on illustrating which existing protocols are reused/extended. We also describe the motivations behind cases where a greenfield approach is needed. We also briefly touch on the maturity level of components.
 
 --- middle
 
 # Introduction
 
-TODO Introduction
+While SCION  was initially developed in academia, the architecture  has now "slipped out of the lab" and counts its early productive deployments (including the Swiss inter-banking network SSFN).
+The architecture consists of a system of  related components. A subset of them is essential to set up end to end SCION connectivity, while others are add-ons aiming at providing additional functionality, security, or backwards compatibility. 
+
+For a generic overview of SCION, please refer to {{DEKATER2022}}, that describes the motivation behind it, its main components and existing deployments.
+
+# Minimal stack - core components
+
+Among the core components, SCION's data plane carries out secure path-aware forwarding. Its control plane takes case of routing, while SCION's unique trust model relies on its own SCION PKI.
 
 
-# Conventions and Definitions
+
+## Routing - Control Plane
+
+## Forwarding - Data plane
+
+###  SCION and Segment Routing  
+
+
+
+
+
+## Conventions and Definitions
 
 {::boilerplate bcp14-tagged}
+
+#
 
 
 # Security Considerations

--- a/draft-rustignoli-panrg-scion-components.md
+++ b/draft-rustignoli-panrg-scion-components.md
@@ -264,7 +264,7 @@ On a first sight, it might seem that SCION control plane takes care of similar d
 
 - *Multipath.* SCION ASes can select PCBs according to their policies, and register the corresponding path segments, making them available to other ASes and end hosts. SCION hosts can leverage a wide range of inter-domain paths, selecting them hop by hop based on application requirements or path conditions.
 Another mechanism is BGP mutlipath {{RFC7911}}, focus on providing a backup path. However, it does not allow end hosts to select end to end path, and it faces scalability concerns  typical of BGP, as discussed in the above mentioned RFC.
-Such concerns motivate an alternative approach as SCION.   
+Such concerns motivate an alternative approach as SCION.
 
 - *Hop by hop path authorization.* SCION packets can only be forwarded along authorized segments. This is achieved thanks to message authentication codes (MACs) within each hop field. During beaconing, each AS control's plane creates MACs, that are then verified at forwarding. This gives end hosts strong guarantees about the path where the data is routed. Other approaches, as BGPSec ({{RFC8205}}), suffer from challenges with scalability, and introduce circular dependencies [137] and global kill switches [441]
 TODO: if we keep this, add citations from book
@@ -282,14 +282,14 @@ TODO: Is SCION immune form such issues (as there is no convergence)?
 
 - *Fault isolation.* As the SCION routing process is divided in intra-ISD and inter-ISD, faults can have a more limited impact.
 On the other hand, a single faulty BGP speaker can adversely impact routing globally.
-TODO: I would be a bit more precise: what kind of fault would be contained? A path service going nuts or being compromised? And BGP is bad, but maybe we should mention that some of the issues (like hijacking) are mitigated by RPKI.  
+TODO: I would be a bit more precise: what kind of fault would be contained? A path service going nuts or being compromised? And BGP is bad, but maybe we should mention that some of the issues (like hijacking) are mitigated by RPKI.
 
 
 - *Authenticated control messages.* BGP has no built-in security mechanisms and does not provide any tools for ASes to authenticate the information they receive through BGP update messages. This opens up a multitude of attack opportunities. SCION control messages, instead, are all authenticated.
 In addition, SCION comprises the SCION Control Message Protocol (SCMP), which  is analogous to the Internet Control Message Protocol (ICMP). It provides functionality for network diagnostics, such as ping and traceroute, and error messages that signal packet processing or network-layer problems.
 TODO: I'm not sure how much I want to go into SCMP here.. Especially as SCMP packets are only authenticated if DRKey/SPAO are used
 
-The SCION control plane is dependent on the control-plane PKI {{#pki}} for authenticating control information.
+The SCION control plane is dependent on the control-plane PKI (#pki) for authenticating control information.
 TODO: Maybe we could go into more detail (i.e. verifying a path with CP certificates?) Maybe we can do this in the PKI section?
 
 

--- a/draft-rustignoli-panrg-scion-components.md
+++ b/draft-rustignoli-panrg-scion-components.md
@@ -196,9 +196,18 @@ TODO: IMHO while in the other draft we focused on describing services and how ea
 {::boilerplate bcp14-tagged}
 
 # Minimal stack - core components
+In order to establish end to end connectivity, SCION relies on three main components.
+The control plane is responsible for discovering and disseminating routing information. Route discovery is performed by each autonomous system (AS) thanks to an authenticated path-exploration mechanism called beaconing.
+SCION end hosts query their respective AS control plane and obtain authenticated and authorized network paths, in the form of path segments. End hosts select one or more of the end to end network paths, based on the application requirements (i.e.,  latency). End hosts then craft SCION packets containing the end-to end path to the destination.
+The data plane is responsible for authenticating at each hop and forwarding SCION packets.
+
+Both the control and data plane rely on the control-plane PKI for authentication and authorization. SCION's authentication mechanisms aim at protecting not only the origin (as in today's internet), rather the whole end to end path. SCION Autonomous systems are organised in Isolation Domains (ISDs), that internally share an uniform trust environment. This makes the SCION CP-PKI distinct from other PKIs (i.e. web PKI, RPKI).  
+TODO: talk about monopoly vs oligopoly and why this is important (but maybe in the CP part)?
+
+
 Among the core components, SCION's data plane carries out secure path-aware forwarding. Its control plane takes case of routing, and relies on the SCION PKI to execute cryptographic .
 
-Core components are all deployed in production (i.e. they power the SSFN, there are multiple implementations)
+Core components are all deployed in production (i.e. they power the SSFN, there are multiple implementations). They have multiple implementations (including a high performance one).
 
 ## Routing - Control Plane
 TODO: use content that was discarded in overview draft (SCION vs BGP, SCION vs RPKI) https://github.com/scionassociation/scion-overview_I-D/blob/8259808cbbd41e8c1d8e39eb7ffc63b8d516433c/draft-perrig-scion-overview.md

--- a/draft-rustignoli-panrg-scion-components.md
+++ b/draft-rustignoli-panrg-scion-components.md
@@ -521,15 +521,30 @@ A possible integration of their path-aware properties remain for now an open que
 TODO:  (inclding BGP with colors, semantic routing, ...)
 
 
-### SCION and previous attempts (RFC9049)
-RFC9049 {{RFC9049}} describes previous failed attempts in deploying path-aware networking.
-How does SCION differ from previous failed attempts to deploy path-aware networking? Why?
+### SCION and previous attempts with path-aware routing
+RFC9049 {{RFC9049}} illustrates obstacles and lessons learned in previous attempts.
+SCION differs from previous attempts to deploy path-aware networking.
+We therefore discuss how SCION relates to some of these lessons, and how it differs from previous attempts.
 
-- ...
+- *Justifying deployment*:
+As early adopters show, SCION can be deployed in existing networks and provide benefits for ISPs without high impact changes. In addition, it provides properties that are not achievable with existing protocols and are needed on a future Internet.
+The reader should keep in mind that justifying why such properties are needed is outside of the scope of this document, and might be a topic for a dedicated gap analysis.
+
+- *Benefits for early adopters and partial deployments*
+--> Early adopters (like in the SSFN) can benefit from SICON properties, especially in industries with higher availability requirements.
+With SIG and compatibility mechanisms, endpoints upgrades are not needed. even non-native SCION end hosts can benefit from its properties.
+SCION needs to be deployed continuously between ASes in the SCION part. However, SICON only requires inter-domain hops along the path to be upgraded. This makes it a bit easier to deploy.
+
+- *Relationship to end-to-end protocols*: In SCION it is end-hosts who select inter-domain paths, as routers simply verify path autorization and forward packets.
+SCION path selection is therefore performed at endpoints, and end-hosts can leverage existing end-to-end protocol mechanisms to switch paths, rather than compete with them.
+
+- *Paying for path-awareness* Experiences with early adopter ISPs in Europe show that ISPs are able to sell SCION as premium business connectivity. As an example, ISPs Swisscom, Sunrise and Switch all provide a SCION business offering.
+
+- *Keeping per-connection state & keeping traffic in the fast-path*: SCION is doing it
 
 TODO: look at p. 582 of the Book
-Sometimes SCION can build on top of the existing (i.e., RPKI), sometimes we believe a different approach is needed (i.e. Segment Routing)...
 
+We briefly discuss implications of {{RFC5218}} (What Makes for a Successful Protocol?) in {{I-D.dekater-scion-overview}}. Overall, because of the reasons discussed above, we believe SCION avoid many of the other protocol's pitfalls, and can therefore be deployed and standardised.
 
 # Transition mechanisms
 As we presented in {{I-D.dekater-scion-overview}}, SCION comprises multiple transition mechanisms that allow an incremental deployment and coexistence with existing protocols.

--- a/draft-rustignoli-panrg-scion-components.md
+++ b/draft-rustignoli-panrg-scion-components.md
@@ -364,7 +364,7 @@ For an overview of the process to create and disseminate path information, refer
 ### Key properties in relationship to existing protocols
 On a first sight, it might seem that SCION control plane takes care of similar duties as of BGP. While both focus on disseminating routing information, there are substantial differences in their mechanisms and properties offered. We describe the core properties provided by the SCION control plane, and its relationships with existing protocols.
 
-- *Host addressing.*.  SCION decouples routing from end-host addressing: inter-domain routing is based on ISD-AS tuples rather than on end-host addresses, making SCION agnostic to end-host addressing.  
+- *Host addressing.*.  SCION decouples routing from end-host addressing: inter-domain routing is based on ISD-AS tuples rather than on end-host addresses, making SCION agnostic to end-host addressing.
 This design decision  has two outcomes: first of all SCION can reuse existing host addressing scheme, as IPv6,  IPv4, or others. Second, its control plane does not carry carry prefix information, avoiding known issues of using routing tables (i.e., scalability, need for dedicated hardware).
 
 - *Multipath.* SCION ASes can select PCBs according to their policies, and register the corresponding path segments, making them available to other ASes and end hosts. SCION hosts can leverage a wide range of inter-domain paths, selecting them at each hop based on application requirements or path conditions.
@@ -385,7 +385,7 @@ In addition, in certain situations, BGP will never converge to a stable state, o
 
 - *Transparency.* SCION end-hosts have full visibility about the inter-domain path where their data is forwarded.
 This is a property that is missing in traditional IP networks, where routing decisions are made by each hop, therefore end-hosts have no visibility nor guarantees on where their traffic is forwarded.
-In addition, users have visibility on the roots of trust that are used to forward traffic.  
+In addition, users have visibility on the roots of trust that are used to forward traffic.
 SCION therefore makes it harder to redirect traffic through an adversary's vantage point.
 In addition, it gives end-users the ability to select which parts of the Internet to trust.
 This is particularly relevant for workloads that currently use segregated networks.
@@ -475,7 +475,9 @@ The CP-PKI is based on certificates that follow the X.509v3 standard {{RFC5280}}
 Trust within an ISD is normally bootstrapped with an initial ceremony. Subsequent updates to the root of trust are handled automatically.
 
 ## Related work
-We illustrate the relationships between SCION and other protocols. For protocols that are deployed in the wild, we discuss what properties can be achieved and what propertyes can only be achieved with an approach like SCION.
+A question that is often asked is wether SCION could simply reuse or extend existing protocols.
+We try to clarify this question, giving an overview of the relationships between SCION and other approaches.
+For protocols that are deployed in the wild, we discuss what properties can be achieved and what propertyes can only be achieved with an approach like SCION.
 
 ###  SCION and Segment Routing
 Given its path-aware properties, some of SCION's characteristics might seem similar to the ones provided by Segment Routing (SR) {{RFC8402}}. There are, however, fundamental differences that distinguish and motivate SCION.
@@ -498,6 +500,8 @@ How does SCION differ from previous failed attempts to deploy path-aware network
 - ...
 
 TODO: look at p. 582 of the Book
+Sometimes SCION can build on top of the existing (i.e., RPKI), sometimes we believe a different approach is needed (i.e. Segment Routing)...
+
 
 # Transition mechanisms
 As we presented in {{I-D.dekater-scion-overview}}, SCION comprises multiple transition mechanisms that allow an incremental deployment and coexistence with existing protocols.
@@ -555,11 +559,6 @@ We described key SCION components with their properties and dependencies.
 TODO: I would add some comments on how SCION avoids some of the issues mentioned in {{RFC9049}}
 Also mention that the most important core components are formally verified.
 
-
-
-# Security Considerations
-
-TODO Security
 
 
 # IANA Considerations

--- a/draft-rustignoli-panrg-scion-components.md
+++ b/draft-rustignoli-panrg-scion-components.md
@@ -493,7 +493,7 @@ SCION indeed does not provide, by design, IP authorisation. Rather, as we furthe
 ### SCION and previous attempts (RFC9049)
 How does SCION differ from previous failed attempts to deploy path-aware networking? Why?
 - *Bananas*:
-- ... 
+- ...
 
 # Transition mechanisms
 As we presented in {{I-D.dekater-scion-overview}}, SCION comprises multiple transition mechanisms that allow an incremental deployment and coexistence with existing protocols.


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionassociation/scion-components_i-d/1)
<!-- Reviewable:end -->

- [x] Start with a section describing the properties we think a good global Internetwork must contain: security, scalability, availability in case of failure, transparency, multi-path/flexibility, end-host control... Then that SCION was developed to meet these property requirements.
- [x] Discussion of each property for each core component (I am not sure about the structure: whether to take the core components as upper level, and the properties as the lower level, or the other way around).
For each property: how SCION achieves this property, in relation to the existing Internet. I think you can re-use all property content you already wrote, this is more a matter of re-organizing the content.=
- [x] Related work section: RPKI,  BGPSec, Semantic Routing (Add)
We should make it clear: what protocols are we reusing, which ones are we extending, which ones are we replacing and not reusing …. We should explain clearly why we are not reusing existing protocols.
- [x] Conclude with dependency analysis, which explains very nicely that the core components cannot really exist on their own (except maybe for the CP-PKI). 
- [ ] Transition mechanism & additional components: remove or rework

General feedback: 
- [ ] Make it more clear why we do not reuse existing protocols
- [ ]  RFC9049: use it as a filter for our ideas. Explain why SCION considers lessons learned
- [x] Use RFC 7418  to explain and motivate what should go into IETF and what should go into IRTF --> I guess this will pop up in discussions. Some we are roughly at half and half, and some of the work should be IETF. I think this should not be in the draft. 