### PR TITLE
references and small updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ lib
 report.xml
 venv/
 .DS_Store
+.vscode/


### PR DESCRIPTION
- Updated references and adde link to CP draft
- Design goals: made wording more precise about Path authorization/validation, mentioned that SCION does not provide encryption
- Removed mention of PCFS, as it is used only within SCIOON publications
- Added EPIC as an extension for path validation.
- Updated .gitignore

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionassociation/scion-components_I-D/15)
<!-- Reviewable:end -->
